### PR TITLE
0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,12 @@
+Changelog
+---------
+
+**0.2.0**
+
+- fix error when creating only a volume group without a logical volume
+- add Molecule test for VG, VG+LV, VG+LV+FS, VG+LV+FS+MOUNT
+- add Molecule LVM mirror example/test
+
+**0.1.1**
+
+- initial commit

--- a/README.md
+++ b/README.md
@@ -8,6 +8,11 @@ ansible-role-lvm
 
 This Ansible roles installs Linux Logical Volume Manager (LVM) resources like `Volume Groups` (VG), `Logical Volumes` (LV) and handles `filesystems` creation and `mountpoints`.
 
+Changelog
+---------
+
+see [CHANGELOG](https://github.com/githubixx/ansible-role-lvm/blob/master/CHANGELOG.md)
+
 Role Variables
 --------------
 

--- a/README.md
+++ b/README.md
@@ -267,6 +267,11 @@ Example 2 (assign tag to role):
       tags: role-lvm
 ```
 
+More examples
+-------------
+
+There are a few more examples used for testing this role. See [molecule](https://github.com/githubixx/ansible-role-lvm/tree/master/molecule) directories.
+
 Testing
 -------
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -15,7 +15,7 @@ lvm_vgs: []
 
 
 # As previous example but also create a logical volume "test-lv-01"
-# and allocate 10% of the available VG space. 
+# and allocate 10% of the available VG space.
 #
 # lvm_vgs:
 #   - vgname: test-vg-01
@@ -108,7 +108,7 @@ lvm_vgs: []
 # can add whatever packages you want to install to the list.
 #
 # By default only tools needed for "ext(2|3|4)" or "xfs" are installed.
-# For other filesystems you may need "btrfsprogs/btrfs-progs" or 
+# For other filesystems you may need "btrfsprogs/btrfs-progs" or
 # "dosfstools" e.g.
 #
 

--- a/molecule/kvm-debian-20-only/converge.yml
+++ b/molecule/kvm-debian-20-only/converge.yml
@@ -1,0 +1,25 @@
+---
+# Copyright (C) 2021 Robert Wimmer
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+- hosts: test-lvm-ubuntu2004
+  vars_files:
+    - vars/test-lvm-ubuntu2004_create.yml 
+  remote_user: vagrant
+  become: true
+  gather_facts: true
+  tasks:
+    - name: Include LVM role
+      include_role:
+        name: githubixx.lvm
+
+- hosts: test-lvm-ubuntu2004
+  vars_files:
+    - vars/test-lvm-ubuntu2004_delete.yml
+  remote_user: vagrant
+  become: true
+  gather_facts: true
+  tasks:
+    - name: Include LVM role
+      include_role:
+        name: githubixx.lvm

--- a/molecule/kvm-debian-20-only/molecule.yml
+++ b/molecule/kvm-debian-20-only/molecule.yml
@@ -1,0 +1,47 @@
+---
+# Copyright (C) 2021 Robert Wimmer
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+dependency:
+  name: galaxy
+
+driver:
+  name: vagrant
+  provider:
+    name: libvirt
+    type: libvirt
+    options:
+      memory: 192
+      cpus: 2
+
+platforms:
+  - name: test-lvm-ubuntu2004
+    box: generic/ubuntu2004
+    provider_raw_config_args:
+      - "storage :file, :type => 'qcow2', :device => 'vdb', :size => '1G'"
+      - "storage :file, :type => 'qcow2', :device => 'vdc', :size => '1G'"
+      - "storage :file, :type => 'qcow2', :device => 'vdd', :size => '1G'"
+      - "storage :file, :type => 'qcow2', :device => 'vde', :size => '1G'"
+    interfaces:
+      - auto_config: true
+        network_name: private_network
+        type: static
+        ip: 192.168.10.10
+
+provisioner:
+  name: ansible
+  connection_options:
+    ansible_ssh_user: vagrant
+    ansible_become: true
+  log: true
+  lint: yamllint . && flake8 && ansible-lint
+
+scenario:
+  name: kvm-vg-only
+  test_sequence:
+    - prepare
+    - converge
+
+verifier:
+  name: ansible
+  enabled: False

--- a/molecule/kvm-debian-20-only/vars/test-lvm-ubuntu2004_create.yml
+++ b/molecule/kvm-debian-20-only/vars/test-lvm-ubuntu2004_create.yml
@@ -1,0 +1,39 @@
+---
+# Copyright (C) 2021 Robert Wimmer
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+lvm_vgs:
+  - vgname: test-vg-01
+    pvs: /dev/vdb
+    state: present
+  - vgname: test-vg-02
+    pvs: /dev/vdc
+    state: present
+    lvm_lvs:
+      - lvname: test-lv-02
+        size: 10%VG
+        state: present
+  - vgname: test-vg-03
+    pvs: /dev/vdd
+    state: present
+    lvm_lvs:
+      - lvname: test-lv-03
+        size: 10%VG
+        state: present
+        fs:
+          type: ext4
+          state: present
+  - vgname: test-vg-04
+    pvs: /dev/vde
+    state: present
+    lvm_lvs:
+      - lvname: test-lv-04
+        size: 10%VG
+        state: present
+        fs:
+          type: ext4
+          state: present
+          mountpoint:
+            state: mounted
+            path:
+              name: /mnt1

--- a/molecule/kvm-debian-20-only/vars/test-lvm-ubuntu2004_delete.yml
+++ b/molecule/kvm-debian-20-only/vars/test-lvm-ubuntu2004_delete.yml
@@ -1,0 +1,48 @@
+---
+# Copyright (C) 2021 Robert Wimmer
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+lvm_vgs:
+  - vgname: test-vg-01
+    pvs: /dev/vdb
+    state: absent
+    force: true
+  - vgname: test-vg-02
+    pvs: /dev/vdc
+    state: absent
+    force: true
+    lvm_lvs:
+      - lvname: test-lv-02
+        size: 10%VG
+        state: absent
+        force: true
+  - vgname: test-vg-03
+    pvs: /dev/vdd
+    state: absent
+    force: true
+    lvm_lvs:
+      - lvname: test-lv-03
+        size: 10%VG
+        state: absent
+        force: true
+        fs:
+          type: ext4
+          state: absent
+          force: true
+  - vgname: test-vg-04
+    pvs: /dev/vde
+    state: absent
+    force: true
+    lvm_lvs:
+      - lvname: test-lv-04
+        size: 10%VG
+        state: absent
+        force: true
+        fs:
+          type: ext4
+          state: absent
+          force: true
+          mountpoint:
+            state: unmounted
+            path:
+              name: /mnt1

--- a/molecule/kvm-lvm-mirror/converge.yml
+++ b/molecule/kvm-lvm-mirror/converge.yml
@@ -1,0 +1,14 @@
+---
+# Copyright (C) 2021 Robert Wimmer
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+- hosts: test-lvm-ubuntu2004
+  vars_files:
+    - vars/test-lvm-ubuntu2004_create.yml 
+  remote_user: vagrant
+  become: true
+  gather_facts: true
+  tasks:
+    - name: Include LVM role
+      include_role:
+        name: githubixx.lvm

--- a/molecule/kvm-lvm-mirror/molecule.yml
+++ b/molecule/kvm-lvm-mirror/molecule.yml
@@ -1,0 +1,45 @@
+---
+# Copyright (C) 2021 Robert Wimmer
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+dependency:
+  name: galaxy
+
+driver:
+  name: vagrant
+  provider:
+    name: libvirt
+    type: libvirt
+    options:
+      memory: 192
+      cpus: 2
+
+platforms:
+  - name: test-lvm-ubuntu2004
+    box: generic/ubuntu2004
+    provider_raw_config_args:
+      - "storage :file, :type => 'qcow2', :device => 'vdb', :size => '1G'"
+      - "storage :file, :type => 'qcow2', :device => 'vdc', :size => '1G'"
+    interfaces:
+      - auto_config: true
+        network_name: private_network
+        type: static
+        ip: 192.168.10.10
+
+provisioner:
+  name: ansible
+  connection_options:
+    ansible_ssh_user: vagrant
+    ansible_become: true
+  log: true
+  lint: yamllint . && flake8 && ansible-lint
+
+scenario:
+  name: kvm-lvm-mirror
+  test_sequence:
+    - prepare
+    - converge
+
+verifier:
+  name: ansible
+  enabled: False

--- a/molecule/kvm-lvm-mirror/vars/test-lvm-ubuntu2004_create.yml
+++ b/molecule/kvm-lvm-mirror/vars/test-lvm-ubuntu2004_create.yml
@@ -1,0 +1,17 @@
+---
+# Copyright (C) 2021 Robert Wimmer
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+lvm_vgs:
+  - vgname: vg01
+    pvs: /dev/vdb,/dev/vdc
+    state: present
+    lvm_lvs:
+      - lvname: lv_mirror
+        size: 100M
+        state: present
+        opts: --type raid1
+        fs:
+          type: ext4
+          opts: -L lv_mirror
+          state: present

--- a/tasks/delete_fs.yml
+++ b/tasks/delete_fs.yml
@@ -6,9 +6,7 @@
   community.general.filesystem:
     dev: "/dev/{{ item.0.vgname }}/{{ item.1.lvname }}"
     state: "{{ item.1.fs.state }}"
-  with_subelements:
-    - "{{ lvm_vgs }}"
-    - lvm_lvs
+  loop: "{{ q('subelements', lvm_vgs, 'lvm_lvs', {'skip_missing': True}) }}"
   loop_control:
     label: >
            "DEV: /dev/{{ item.0.vgname }}/{{ item.1.lvname }} |

--- a/tasks/delete_lvs.yml
+++ b/tasks/delete_lvs.yml
@@ -8,9 +8,7 @@
     lv: "{{ item.1.lvname }}"
     force: "{{ item.1.force }}"
     state: "{{ item.1.state }}"
-  with_subelements:
-    - "{{ lvm_vgs }}"
-    - lvm_lvs
+  loop: "{{ q('subelements', lvm_vgs, 'lvm_lvs', {'skip_missing': True}) }}"
   loop_control:
     label: >
            "LV: {{ item.1.lvname }} |

--- a/tasks/ensure_fs.yml
+++ b/tasks/ensure_fs.yml
@@ -8,9 +8,7 @@
     fstype: "{{ item.1.fs.type }}"
     opts: "{{ item.1.fs.opts | default(omit) }}"
     state: "{{ item.1.fs.state }}"
-  with_subelements:
-    - "{{ lvm_vgs }}"
-    - lvm_lvs
+  loop: "{{ q('subelements', lvm_vgs, 'lvm_lvs', {'skip_missing': True}) }}"
   loop_control:
     label: >
            "DEV: /dev/{{ item.0.vgname }}/{{ item.1.lvname }} |

--- a/tasks/ensure_lvs.yml
+++ b/tasks/ensure_lvs.yml
@@ -12,9 +12,7 @@
     thinpool: "{{ item.1.thinpool | default(omit) }}"
     size: "{{ item.1.size }}"
     state: "{{ item.1.state }}"
-  with_subelements:
-    - "{{ lvm_vgs }}"
-    - lvm_lvs
+  loop: "{{ q('subelements', lvm_vgs, 'lvm_lvs', {'skip_missing': True}) }}"
   loop_control:
     label: >
            "LV: {{ item.1.lvname }} |

--- a/tasks/mounts.yml
+++ b/tasks/mounts.yml
@@ -11,9 +11,7 @@
         mode: "{{ item.1.fs.mountpoint.path.mode | default(omit) }}"
         owner: "{{ item.1.fs.mountpoint.path.owner | default(omit) }}"
         group: "{{ item.1.fs.mountpoint.path.group | default(omit) }}"
-      with_subelements:
-        - "{{ lvm_vgs }}"
-        - lvm_lvs
+      loop: "{{ q('subelements', lvm_vgs, 'lvm_lvs', {'skip_missing': True}) }}"
       loop_control:
         label: "{{ item.1.fs.mountpoint.path.name | default('no directory') }}"
 
@@ -28,9 +26,7 @@
         passno: "{{ item.1.fs.mountpoint.passno | default(omit) }}"
         fstab: "{{ item.1.fs.mountpoint.fstab | default(omit) }}"
         state: "{{ item.1.fs.mountpoint.state }}"
-      with_subelements:
-        - "{{ lvm_vgs }}"
-        - lvm_lvs
+      loop: "{{ q('subelements', lvm_vgs, 'lvm_lvs', {'skip_missing': True}) }}"
       loop_control:
         label: >
                "{{ item.1.fs.mountpoint.src |


### PR DESCRIPTION
- fix error when creating only a volume group without a logical volume
- add Molecule test for VG, VG+LV, VG+LV+FS, VG+LV+FS+MOUNT
- add Molecule LVM mirror example/test
- replace `with_subelements` loop with `loop` keyword
- add `CHANGELOG`
