### PR TITLE
0.4.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,5 +38,4 @@ jobs:
 
       - name: Trigger a new import on Galaxy.
         run: >-
-          ansible-galaxy role import --api-key ${{ secrets.GALAXY_API_KEY }}
-          $(echo ${{ github.repository }} | cut -d/ -f1) $(echo ${{ github.repository }} | cut -d/ -f2)
+          ansible-galaxy role import --token ${{ secrets.GALAXY_API_KEY }} -vvvvvvvv --role-name=$(echo ${{ github.repository }} | cut -d/ -f2 | sed 's/ansible-role-//' | sed 's/-/_/') $(echo ${{ github.repository }} | cut -d/ -f1) $(echo ${{ github.repository }} | cut -d/ -f2)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,5 @@
 ---
-# Copyright (C) 2021-2022 Robert Wimmer
+# Copyright (C) 2021-2024 Robert Wimmer
 # SPDX-License-Identifier: GPL-3.0-or-later
 #
 # This workflow requires a GALAXY_API_KEY secret present in the GitHub

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.4.0
 
 - add resize filesystem `resizefs` item
+- remove support for Ubuntu 18.04 (reached EOL)
 
 ## 0.3.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - add support for Debian 12
 - add support for openSUSE Leap 15.4
 - add support for openSUSE Leap 15.5
+- Molecule: change IP addresses
 
 ## 0.3.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,10 @@
-Changelog
----------
+# Changelog
 
-**0.3.0**
+## 0.4.0
+
+- add resize filesystem `resizefs` item
+
+## 0.3.0
 
 - fix various `ansible-lint` issues
 - update Molecule scenario `kvm-ubuntu-20-only`
@@ -17,12 +20,12 @@ Changelog
 - add Github release action to push new release to Ansible Galaxy
 - `min_ansible_version` variable value should be string / versions should be string in `meta/main.yml`
 
-**0.2.0**
+## 0.2.0
 
 - fix error when creating only a volume group without a logical volume
 - add Molecule test for VG, VG+LV, VG+LV+FS, VG+LV+FS+MOUNT
 - add Molecule LVM mirror example/test
 
-**0.1.1**
+## 0.1.1
 
 - initial commit

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,10 @@
 - remove support for Ubuntu 18.04 (reached EOL)
 - remove support for Debian 10 (reached EOL)
 - remove support for Fedora 35/36 (reached EOL)
+- remove support for openSUSE Leap 15.3 (reached EOL)
 - add support for Fedora 39
+- add support for openSUSE Leap 15.4
+- add support for openSUSE Leap 15.5
 
 ## 0.3.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 - add resize filesystem `resizefs` item
 - remove support for Ubuntu 18.04 (reached EOL)
+- remove support for Debian 10 (reached EOL)
+- remove support for Fedora 35/36 (reached EOL)
+- add support for Fedora 39
 
 ## 0.3.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - remove support for Fedora 35/36 (reached EOL)
 - remove support for openSUSE Leap 15.3 (reached EOL)
 - add support for Fedora 39
+- add support for Debian 12
 - add support for openSUSE Leap 15.4
 - add support for openSUSE Leap 15.5
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@
 - add support for Debian 12
 - add support for openSUSE Leap 15.4
 - add support for openSUSE Leap 15.5
+- add support for Rocky Linux 8/9
+- add support for Almalinux 8/9
 - Molecule: change IP addresses
 
 ## 0.3.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+<!--
+Copyright (C) 2021-2024 Robert Wimmer
+SPDX-License-Identifier: GPL-3.0-or-later
+-->
+
 # Changelog
 
 ## 0.4.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,9 @@ SPDX-License-Identifier: GPL-3.0-or-later
 - add support for openSUSE Leap 15.5
 - add support for Rocky Linux 8/9
 - add support for Almalinux 8/9
+- update Github workflow
 - Molecule: change IP addresses
+- Molecule: fix ansible-lint issues
 
 ## 0.3.0
 

--- a/README.md
+++ b/README.md
@@ -3,18 +3,15 @@ Copyright (C) 2021-2022 Robert Wimmer
 SPDX-License-Identifier: GPL-3.0-or-later
 -->
 
-ansible-role-lvm
-================
+# ansible-role-lvm
 
 This Ansible roles installs Linux Logical Volume Manager (LVM) resources like `Volume Groups` (VG), `Logical Volumes` (LV) and handles `filesystems` creation and `mountpoints`.
 
-Changelog
----------
+## Changelog
 
 see [CHANGELOG](https://github.com/githubixx/ansible-role-lvm/blob/master/CHANGELOG.md)
 
-Role Variables
---------------
+## Role Variables
 
 By default no LVM resources are created. See examples below. The `lvm_vgs` key is the entrypoint for all LVM resources that should be created.
 
@@ -170,9 +167,9 @@ mountpoint:
     name: /vg01lv01
 ```
 
-This of course only works if the mountpoint isn't used by a programm or service.
+This of course only works if the mountpoint isn't used by a program or service.
 
-As deleting filesystems, logical volumes (LV) and volume groups (VG) potentially can destroy your data extra caution should be taken! In this case specifing `state: absent` to delete such a resource isn't enough. `force: true` is also needed. Of course deleting a volume group that still contains a logical volume will fail. Also deleting a logical volume with a filesystem with `state: present` will fail.
+As deleting filesystems, logical volumes (LV) and volume groups (VG) potentially can destroy your data extra caution should be taken! In this case specifying `state: absent` to delete such a resource isn't enough. `force: true` is also needed. Of course deleting a volume group that still contains a logical volume will fail. Also deleting a logical volume with a filesystem with `state: present` will fail.
 
 The following example will unmount the specified mountpoint (`/vg02lv01`) and delete its entry from `/etc/fstab`, will wipe the `ext4`  filesystem, deletes the logical volume (`vg02lv01`) and finally deletes the volume group (`vg02`) (in that order):
 
@@ -230,8 +227,7 @@ In general most options of the following modules are supported:
 [community.general.filesystem](https://docs.ansible.com/ansible/latest/collections/community/general/filesystem_module.html)  
 [ansible.posix.mount](https://docs.ansible.com/ansible/latest/collections/ansible/posix/mount_module.html)  
 
-Dependencies
-------------
+## Dependencies
 
 This role depends on a few Ansible modules:
 
@@ -240,20 +236,18 @@ This role depends on a few Ansible modules:
 [community.general.filesystem](https://docs.ansible.com/ansible/latest/collections/community/general/filesystem_module.html)  
 [ansible.posix.mount](https://docs.ansible.com/ansible/latest/collections/ansible/posix/mount_module.html)  
 
-TODO
-----
+## TODO
 
 Currently the following features are not implemented:
 
-[] Volume Group resize  
-[] Logical Volume resize/shrink  
-[] Logical Volume snapshot  
-[] Logical Volume/Filesystem resize  
+- Volume Group resize  
+- Logical Volume shrink  
+- Logical Volume snapshot  
+- Logical Volume/Filesystem resize  
 
-Example Playbook
-----------------
+## Example Playbook
 
-Example 1 (without role tag):
+### Example 1 (without role tag)
 
 ```yaml
 - hosts: your-host
@@ -261,7 +255,7 @@ Example 1 (without role tag):
     - githubixx.lvm
 ```
 
-Example 2 (assign tag to role):
+### Example 2 (assign tag to role)
 
 ```yaml
 -
@@ -272,13 +266,11 @@ Example 2 (assign tag to role):
       tags: role-lvm
 ```
 
-More examples
--------------
+## More examples
 
 There are a few more examples used for testing this role. See [molecule](https://github.com/githubixx/ansible-role-lvm/tree/master/molecule) directories.
 
-Testing
--------
+## Testing
 
 This role has a small test setup that is created using [Molecule](https://github.com/ansible-community/molecule), libvirt (vagrant-libvirt) and QEMU/KVM. Please see my blog post [Testing Ansible roles with Molecule, libvirt (vagrant-libvirt) and QEMU/KVM](https://www.tauceti.blog/posts/testing-ansible-roles-with-molecule-libvirt-vagrant-qemu-kvm/) how to setup. The test configuration is [here](https://github.com/githubixx/ansible-role-lvm/tree/master/molecule/kvm).
 
@@ -296,12 +288,10 @@ To clean up run
 molecule destroy -s kvm
 ```
 
-License
--------
+## License
 
 [GNU General Public License v3.0 or later](https://spdx.org/licenses/GPL-3.0-or-later.html)
 
-Author Information
-------------------
+## Author Information
 
 [http://www.tauceti.blog](http://www.tauceti.blog)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <!--
-Copyright (C) 2021-2022 Robert Wimmer
+Copyright (C) 2021-2024 Robert Wimmer
 SPDX-License-Identifier: GPL-3.0-or-later
 -->
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-# Copyright (C) 2021-2022 Robert Wimmer
+# Copyright (C) 2021-2024 Robert Wimmer
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 # By default no LVM resources are created. See examples below.

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -18,6 +18,7 @@ galaxy_info:
     - name: Debian
       versions:
         - "bullseye"
+        - "bookworm"
     - name: EL
       versions:
         - "7"

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -13,7 +13,6 @@ galaxy_info:
     - name: ArchLinux
     - name: Ubuntu
       versions:
-        - "bionic"
         - "focal"
         - "jammy"
     - name: Debian

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -24,8 +24,7 @@ galaxy_info:
         - "8"
     - name: Fedora
       versions:
-        - "35"
-        - "36"
+        - "39"
     - name: opensuse
       versions:
         - "15.3"

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,5 +1,5 @@
 ---
-# Copyright (C) 2021-2022 Robert Wimmer
+# Copyright (C) 2021-2024 Robert Wimmer
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 galaxy_info:

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -27,7 +27,8 @@ galaxy_info:
         - "39"
     - name: opensuse
       versions:
-        - "15.3"
+        - "15.4"
+        - "15.5"
   galaxy_tags:
     - linux
     - lvm

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -17,7 +17,6 @@ galaxy_info:
         - "jammy"
     - name: Debian
       versions:
-        - "buster"
         - "bullseye"
     - name: EL
       versions:

--- a/molecule/kvm-lvm-mirror/converge.yml
+++ b/molecule/kvm-lvm-mirror/converge.yml
@@ -1,5 +1,5 @@
 ---
-# Copyright (C) 2021-2022 Robert Wimmer
+# Copyright (C) 2021-2024 Robert Wimmer
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 - hosts: test-lvm-ubuntu2004

--- a/molecule/kvm-lvm-mirror/converge.yml
+++ b/molecule/kvm-lvm-mirror/converge.yml
@@ -2,7 +2,8 @@
 # Copyright (C) 2021-2024 Robert Wimmer
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-- hosts: test-lvm-ubuntu2004
+- name: Include LVM role
+  hosts: test-lvm-ubuntu2004
   vars_files:
     - vars/test-lvm-ubuntu2004_create.yml
   remote_user: vagrant
@@ -10,5 +11,5 @@
   gather_facts: true
   tasks:
     - name: Include LVM role
-      include_role:
+      ansible.builtin.include_role:
         name: githubixx.lvm

--- a/molecule/kvm-lvm-mirror/molecule.yml
+++ b/molecule/kvm-lvm-mirror/molecule.yml
@@ -1,5 +1,5 @@
 ---
-# Copyright (C) 2021-2022 Robert Wimmer
+# Copyright (C) 2021-2024 Robert Wimmer
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 dependency:

--- a/molecule/kvm-lvm-mirror/molecule.yml
+++ b/molecule/kvm-lvm-mirror/molecule.yml
@@ -14,7 +14,7 @@ driver:
 platforms:
   - name: test-lvm-ubuntu2004
     box: generic/ubuntu2004
-    memory: 1024
+    memory: 1536
     cpus: 2
     provider_raw_config_args:
       - "storage :file, :type => 'qcow2', :device => 'vdb', :size => '1G'"
@@ -23,7 +23,7 @@ platforms:
       - auto_config: true
         network_name: private_network
         type: static
-        ip: 192.168.10.10
+        ip: 172.16.10.10
 
 provisioner:
   name: ansible

--- a/molecule/kvm-lvm-mirror/vars/test-lvm-ubuntu2004_create.yml
+++ b/molecule/kvm-lvm-mirror/vars/test-lvm-ubuntu2004_create.yml
@@ -1,5 +1,5 @@
 ---
-# Copyright (C) 2021-2022 Robert Wimmer
+# Copyright (C) 2021-2024 Robert Wimmer
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 lvm_vgs:

--- a/molecule/kvm-ubuntu-20-only/converge.yml
+++ b/molecule/kvm-ubuntu-20-only/converge.yml
@@ -2,7 +2,8 @@
 # Copyright (C) 2021-2024 Robert Wimmer
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-- hosts: test-lvm-ubuntu2004
+- name: Include LVM role
+  hosts: test-lvm-ubuntu2004
   vars_files:
     - vars/test-lvm-ubuntu2004_create.yml
   remote_user: vagrant
@@ -10,10 +11,11 @@
   gather_facts: true
   tasks:
     - name: Include LVM role
-      include_role:
+      ansible.builtin.include_role:
         name: githubixx.lvm
 
-- hosts: test-lvm-ubuntu2004
+- name: Include LVM role
+  hosts: test-lvm-ubuntu2004
   vars_files:
     - vars/test-lvm-ubuntu2004_delete.yml
   remote_user: vagrant
@@ -21,5 +23,5 @@
   gather_facts: true
   tasks:
     - name: Include LVM role
-      include_role:
+      ansible.builtin.include_role:
         name: githubixx.lvm

--- a/molecule/kvm-ubuntu-20-only/converge.yml
+++ b/molecule/kvm-ubuntu-20-only/converge.yml
@@ -1,5 +1,5 @@
 ---
-# Copyright (C) 2021-2022 Robert Wimmer
+# Copyright (C) 2021-2024 Robert Wimmer
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 - hosts: test-lvm-ubuntu2004

--- a/molecule/kvm-ubuntu-20-only/molecule.yml
+++ b/molecule/kvm-ubuntu-20-only/molecule.yml
@@ -1,5 +1,5 @@
 ---
-# Copyright (C) 2021-2022 Robert Wimmer
+# Copyright (C) 2021-2024 Robert Wimmer
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 dependency:

--- a/molecule/kvm-ubuntu-20-only/molecule.yml
+++ b/molecule/kvm-ubuntu-20-only/molecule.yml
@@ -14,7 +14,7 @@ driver:
 platforms:
   - name: test-lvm-ubuntu2004
     box: generic/ubuntu2004
-    memory: 1024
+    memory: 1536
     cpus: 2
     provider_raw_config_args:
       - "storage :file, :type => 'qcow2', :device => 'vdb', :size => '1G'"
@@ -25,7 +25,7 @@ platforms:
       - auto_config: true
         network_name: private_network
         type: static
-        ip: 192.168.10.10
+        ip: 172.16.10.10
 
 provisioner:
   name: ansible

--- a/molecule/kvm-ubuntu-20-only/vars/test-lvm-ubuntu2004_create.yml
+++ b/molecule/kvm-ubuntu-20-only/vars/test-lvm-ubuntu2004_create.yml
@@ -1,5 +1,5 @@
 ---
-# Copyright (C) 2021-2022 Robert Wimmer
+# Copyright (C) 2021-2024 Robert Wimmer
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 lvm_vgs:

--- a/molecule/kvm-ubuntu-20-only/vars/test-lvm-ubuntu2004_delete.yml
+++ b/molecule/kvm-ubuntu-20-only/vars/test-lvm-ubuntu2004_delete.yml
@@ -1,5 +1,5 @@
 ---
-# Copyright (C) 2021-2022 Robert Wimmer
+# Copyright (C) 2021-2024 Robert Wimmer
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 lvm_vgs:

--- a/molecule/kvm/converge.yml
+++ b/molecule/kvm/converge.yml
@@ -1,5 +1,5 @@
 ---
-# Copyright (C) 2021-2022 Robert Wimmer
+# Copyright (C) 2021-2024 Robert Wimmer
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 - hosts: test-lvm-ubuntu2204

--- a/molecule/kvm/converge.yml
+++ b/molecule/kvm/converge.yml
@@ -2,7 +2,8 @@
 # Copyright (C) 2021-2024 Robert Wimmer
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-- hosts: test-lvm-ubuntu2204
+- name: Include LVM role
+  hosts: test-lvm-ubuntu2204
   vars_files:
     - vars/test-lvm-minimal.yml
   remote_user: vagrant
@@ -10,10 +11,11 @@
   gather_facts: true
   tasks:
     - name: Include LVM role
-      include_role:
+      ansible.builtin.include_role:
         name: githubixx.lvm
 
-- hosts: test-lvm-ubuntu2004
+- name: Include LVM role
+  hosts: test-lvm-ubuntu2004
   vars_files:
     - vars/test-lvm-ubuntu2004_create.yml
   remote_user: vagrant
@@ -21,10 +23,11 @@
   gather_facts: true
   tasks:
     - name: Include LVM role
-      include_role:
+      ansible.builtin.include_role:
         name: githubixx.lvm
 
-- hosts: test-lvm-ubuntu1804
+- name: Include LVM role
+  hosts: test-lvm-fedora39
   vars_files:
     - vars/test-lvm-minimal.yml
   remote_user: vagrant
@@ -32,10 +35,11 @@
   gather_facts: true
   tasks:
     - name: Include LVM role
-      include_role:
+      ansible.builtin.include_role:
         name: githubixx.lvm
 
-- hosts: test-lvm-debian10
+- name: Include LVM role
+  hosts: test-lvm-fedora36
   vars_files:
     - vars/test-lvm-minimal.yml
   remote_user: vagrant
@@ -43,10 +47,11 @@
   gather_facts: true
   tasks:
     - name: Include LVM role
-      include_role:
+      ansible.builtin.include_role:
         name: githubixx.lvm
 
-- hosts: test-lvm-fedora35
+- name: Include LVM role
+  hosts: test-lvm-centos7
   vars_files:
     - vars/test-lvm-minimal.yml
   remote_user: vagrant
@@ -54,32 +59,11 @@
   gather_facts: true
   tasks:
     - name: Include LVM role
-      include_role:
+      ansible.builtin.include_role:
         name: githubixx.lvm
 
-- hosts: test-lvm-fedora36
-  vars_files:
-    - vars/test-lvm-minimal.yml
-  remote_user: vagrant
-  become: true
-  gather_facts: true
-  tasks:
-    - name: Include LVM role
-      include_role:
-        name: githubixx.lvm
-
-- hosts: test-lvm-centos7
-  vars_files:
-    - vars/test-lvm-minimal.yml
-  remote_user: vagrant
-  become: true
-  gather_facts: true
-  tasks:
-    - name: Include LVM role
-      include_role:
-        name: githubixx.lvm
-
-- hosts: test-lvm-arch
+- name: Include LVM role
+  hosts: test-lvm-arch
   vars_files:
     - vars/test-lvm-arch_create.yml
   remote_user: vagrant
@@ -87,10 +71,11 @@
   gather_facts: true
   tasks:
     - name: Include LVM role
-      include_role:
+      ansible.builtin.include_role:
         name: githubixx.lvm
 
-- hosts: test-lvm-arch
+- name: Include LVM role
+  hosts: test-lvm-arch
   vars_files:
     - vars/test-lvm-arch_delete.yml
   remote_user: vagrant
@@ -98,10 +83,11 @@
   gather_facts: true
   tasks:
     - name: Include LVM role
-      include_role:
+      ansible.builtin.include_role:
         name: githubixx.lvm
 
-- hosts: test-lvm-opensuse-leap-15-3
+- name: Include LVM role
+  hosts: test-lvm-opensuse-leap-15-4
   vars_files:
     - vars/test-lvm-minimal.yml
   remote_user: vagrant
@@ -109,10 +95,11 @@
   gather_facts: true
   tasks:
     - name: Include LVM role
-      include_role:
+      ansible.builtin.include_role:
         name: githubixx.lvm
 
-- hosts: test-lvm-opensuse-leap-15-4
+- name: Include LVM role
+  hosts: test-lvm-opensuse-leap-15-5
   vars_files:
     - vars/test-lvm-minimal.yml
   remote_user: vagrant
@@ -120,10 +107,11 @@
   gather_facts: true
   tasks:
     - name: Include LVM role
-      include_role:
+      ansible.builtin.include_role:
         name: githubixx.lvm
 
-- hosts: test-lvm-debian11
+- name: Include LVM role
+  hosts: test-lvm-debian11
   vars_files:
     - vars/test-lvm-minimal.yml
   remote_user: vagrant
@@ -131,5 +119,65 @@
   gather_facts: true
   tasks:
     - name: Include LVM role
-      include_role:
+      ansible.builtin.include_role:
+        name: githubixx.lvm
+
+- name: Include LVM role
+  hosts: test-lvm-debian12
+  vars_files:
+    - vars/test-lvm-minimal.yml
+  remote_user: vagrant
+  become: true
+  gather_facts: true
+  tasks:
+    - name: Include LVM role
+      ansible.builtin.include_role:
+        name: githubixx.lvm
+
+- name: Include LVM role Rocky Linux 8
+  hosts: test-lvm-rocky8
+  vars_files:
+    - vars/test-lvm-minimal.yml
+  remote_user: vagrant
+  become: true
+  gather_facts: true
+  tasks:
+    - name: Include LVM role
+      ansible.builtin.include_role:
+        name: githubixx.lvm
+
+- name: Include LVM role Rocky Linux 9
+  hosts: test-lvm-rocky9
+  vars_files:
+    - vars/test-lvm-minimal.yml
+  remote_user: vagrant
+  become: true
+  gather_facts: true
+  tasks:
+    - name: Include LVM role
+      ansible.builtin.include_role:
+        name: githubixx.lvm
+
+- name: Include LVM role Almalinux 8
+  hosts: test-lvm-alma8
+  vars_files:
+    - vars/test-lvm-minimal.yml
+  remote_user: vagrant
+  become: true
+  gather_facts: true
+  tasks:
+    - name: Include LVM role
+      ansible.builtin.include_role:
+        name: githubixx.lvm
+
+- name: Include LVM role Almalinux 9
+  hosts: test-lvm-alma9
+  vars_files:
+    - vars/test-lvm-minimal.yml
+  remote_user: vagrant
+  become: true
+  gather_facts: true
+  tasks:
+    - name: Include LVM role
+      ansible.builtin.include_role:
         name: githubixx.lvm

--- a/molecule/kvm/molecule.yml
+++ b/molecule/kvm/molecule.yml
@@ -1,5 +1,5 @@
 ---
-# Copyright (C) 2021-2022 Robert Wimmer
+# Copyright (C) 2021-2024 Robert Wimmer
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 dependency:

--- a/molecule/kvm/molecule.yml
+++ b/molecule/kvm/molecule.yml
@@ -101,6 +101,17 @@ platforms:
         network_name: private_network
         type: static
         ip: 192.168.10.110
+  - name: test-lvm-debian12
+    box: generic/debian12
+    memory: 1024
+    cpus: 2
+    provider_raw_config_args:
+      - "storage :file, :type => 'qcow2', :device => 'vdb', :size => '1G'"
+    interfaces:
+      - auto_config: true
+        network_name: private_network
+        type: static
+        ip: 192.168.10.120
 
 provisioner:
   name: ansible

--- a/molecule/kvm/molecule.yml
+++ b/molecule/kvm/molecule.yml
@@ -34,17 +34,6 @@ platforms:
         network_name: private_network
         type: static
         ip: 192.168.10.20
-  - name: test-lvm-ubuntu1804
-    box: generic/ubuntu1804
-    memory: 1024
-    cpus: 2
-    provider_raw_config_args:
-      - "storage :file, :type => 'qcow2', :device => 'vdb', :size => '1G'"
-    interfaces:
-      - auto_config: true
-        network_name: private_network
-        type: static
-        ip: 192.168.10.30
   - name: test-lvm-debian10
     box: generic/debian10
     memory: 1024

--- a/molecule/kvm/molecule.yml
+++ b/molecule/kvm/molecule.yml
@@ -68,8 +68,8 @@ platforms:
         network_name: private_network
         type: static
         ip: 192.168.10.80
-  - name: test-lvm-opensuse-leap-15-3
-    box: opensuse/Leap-15.3.x86_64
+  - name: test-lvm-opensuse-leap-15-4
+    box: opensuse/Leap-15.4.x86_64
     memory: 1024
     cpus: 2
     provider_raw_config_args:
@@ -79,8 +79,8 @@ platforms:
         network_name: private_network
         type: static
         ip: 192.168.10.90
-  - name: test-lvm-opensuse-leap-15-4
-    box: opensuse/Leap-15.4.x86_64
+  - name: test-lvm-opensuse-leap-15-5
+    box: opensuse/Leap-15.5.x86_64
     memory: 1024
     cpus: 2
     provider_raw_config_args:

--- a/molecule/kvm/molecule.yml
+++ b/molecule/kvm/molecule.yml
@@ -22,7 +22,7 @@ platforms:
       - auto_config: true
         network_name: private_network
         type: static
-        ip: 192.168.10.10
+        ip: 172.16.10.10
   - name: test-lvm-ubuntu2004
     box: generic/ubuntu2004
     memory: 1024
@@ -33,7 +33,7 @@ platforms:
       - auto_config: true
         network_name: private_network
         type: static
-        ip: 192.168.10.20
+        ip: 172.16.10.20
   - name: test-lvm-fedora39
     box: generic/fedora39
     memory: 1024
@@ -44,7 +44,7 @@ platforms:
       - auto_config: true
         network_name: private_network
         type: static
-        ip: 192.168.10.60
+        ip: 172.16.10.30
   - name: test-lvm-centos7
     box: generic/centos7
     memory: 1024
@@ -55,7 +55,7 @@ platforms:
       - auto_config: true
         network_name: private_network
         type: static
-        ip: 192.168.10.70
+        ip: 172.16.10.40
   - name: test-lvm-arch
     box: archlinux/archlinux
     memory: 1024
@@ -67,7 +67,7 @@ platforms:
       - auto_config: true
         network_name: private_network
         type: static
-        ip: 192.168.10.80
+        ip: 172.16.10.50
   - name: test-lvm-opensuse-leap-15-4
     box: opensuse/Leap-15.4.x86_64
     memory: 1024
@@ -78,7 +78,7 @@ platforms:
       - auto_config: true
         network_name: private_network
         type: static
-        ip: 192.168.10.90
+        ip: 172.16.10.60
   - name: test-lvm-opensuse-leap-15-5
     box: opensuse/Leap-15.5.x86_64
     memory: 1024
@@ -89,7 +89,7 @@ platforms:
       - auto_config: true
         network_name: private_network
         type: static
-        ip: 192.168.10.100
+        ip: 172.16.10.70
   - name: test-lvm-debian11
     box: generic/debian11
     memory: 1024
@@ -100,7 +100,7 @@ platforms:
       - auto_config: true
         network_name: private_network
         type: static
-        ip: 192.168.10.110
+        ip: 172.16.10.80
   - name: test-lvm-debian12
     box: generic/debian12
     memory: 1024
@@ -111,7 +111,7 @@ platforms:
       - auto_config: true
         network_name: private_network
         type: static
-        ip: 192.168.10.120
+        ip: 172.16.10.90
 
 provisioner:
   name: ansible

--- a/molecule/kvm/molecule.yml
+++ b/molecule/kvm/molecule.yml
@@ -14,7 +14,7 @@ driver:
 platforms:
   - name: test-lvm-ubuntu2204
     box: generic/ubuntu2204
-    memory: 1024
+    memory: 1536
     cpus: 2
     provider_raw_config_args:
       - "storage :file, :type => 'qcow2', :device => 'vdb', :size => '1G'"
@@ -25,7 +25,7 @@ platforms:
         ip: 172.16.10.10
   - name: test-lvm-ubuntu2004
     box: generic/ubuntu2004
-    memory: 1024
+    memory: 1536
     cpus: 2
     provider_raw_config_args:
       - "storage :file, :type => 'qcow2', :device => 'vdb', :size => '1G'"
@@ -36,7 +36,7 @@ platforms:
         ip: 172.16.10.20
   - name: test-lvm-fedora39
     box: generic/fedora39
-    memory: 1024
+    memory: 1536
     cpus: 2
     provider_raw_config_args:
       - "storage :file, :type => 'qcow2', :device => 'vdb', :size => '1G'"
@@ -47,7 +47,7 @@ platforms:
         ip: 172.16.10.30
   - name: test-lvm-centos7
     box: generic/centos7
-    memory: 1024
+    memory: 1536
     cpus: 2
     provider_raw_config_args:
       - "storage :file, :type => 'qcow2', :device => 'vdb', :size => '1G'"
@@ -58,7 +58,7 @@ platforms:
         ip: 172.16.10.40
   - name: test-lvm-arch
     box: archlinux/archlinux
-    memory: 1024
+    memory: 1536
     cpus: 2
     provider_raw_config_args:
       - "storage :file, :type => 'qcow2', :device => 'vdb', :size => '1G'"
@@ -70,7 +70,7 @@ platforms:
         ip: 172.16.10.50
   - name: test-lvm-opensuse-leap-15-4
     box: opensuse/Leap-15.4.x86_64
-    memory: 1024
+    memory: 1536
     cpus: 2
     provider_raw_config_args:
       - "storage :file, :type => 'qcow2', :device => 'vdb', :size => '1G'"
@@ -81,7 +81,7 @@ platforms:
         ip: 172.16.10.60
   - name: test-lvm-opensuse-leap-15-5
     box: opensuse/Leap-15.5.x86_64
-    memory: 1024
+    memory: 1536
     cpus: 2
     provider_raw_config_args:
       - "storage :file, :type => 'qcow2', :device => 'vdb', :size => '1G'"
@@ -92,7 +92,7 @@ platforms:
         ip: 172.16.10.70
   - name: test-lvm-debian11
     box: generic/debian11
-    memory: 1024
+    memory: 1536
     cpus: 2
     provider_raw_config_args:
       - "storage :file, :type => 'qcow2', :device => 'vdb', :size => '1G'"
@@ -103,7 +103,7 @@ platforms:
         ip: 172.16.10.80
   - name: test-lvm-debian12
     box: generic/debian12
-    memory: 1024
+    memory: 1536
     cpus: 2
     provider_raw_config_args:
       - "storage :file, :type => 'qcow2', :device => 'vdb', :size => '1G'"
@@ -112,6 +112,50 @@ platforms:
         network_name: private_network
         type: static
         ip: 172.16.10.90
+  - name: test-lvm-rocky8
+    box: generic/rocky8
+    memory: 1536
+    cpus: 2
+    provider_raw_config_args:
+      - "storage :file, :type => 'qcow2', :device => 'vdb', :size => '1G'"
+    interfaces:
+      - auto_config: true
+        network_name: private_network
+        type: static
+        ip: 172.16.10.100
+  - name: test-lvm-rocky9
+    box: rockylinux/9
+    memory: 1536
+    cpus: 2
+    provider_raw_config_args:
+      - "storage :file, :type => 'qcow2', :device => 'vdb', :size => '1G'"
+    interfaces:
+      - auto_config: true
+        network_name: private_network
+        type: static
+        ip: 172.16.10.110
+  - name: test-lvm-alma8
+    box: almalinux/8
+    memory: 1536
+    cpus: 2
+    provider_raw_config_args:
+      - "storage :file, :type => 'qcow2', :device => 'vdb', :size => '1G'"
+    interfaces:
+      - auto_config: true
+        network_name: private_network
+        type: static
+        ip: 172.16.10.120
+  - name: test-lvm-alma9
+    box: almalinux/9
+    memory: 1536
+    cpus: 2
+    provider_raw_config_args:
+      - "storage :file, :type => 'qcow2', :device => 'vdb', :size => '1G'"
+    interfaces:
+      - auto_config: true
+        network_name: private_network
+        type: static
+        ip: 172.16.10.130
 
 provisioner:
   name: ansible

--- a/molecule/kvm/molecule.yml
+++ b/molecule/kvm/molecule.yml
@@ -34,19 +34,8 @@ platforms:
         network_name: private_network
         type: static
         ip: 192.168.10.20
-  - name: test-lvm-fedora35
-    box: generic/fedora35
-    memory: 1024
-    cpus: 2
-    provider_raw_config_args:
-      - "storage :file, :type => 'qcow2', :device => 'vdb', :size => '1G'"
-    interfaces:
-      - auto_config: true
-        network_name: private_network
-        type: static
-        ip: 192.168.10.50
-  - name: test-lvm-fedora36
-    box: generic/fedora36
+  - name: test-lvm-fedora39
+    box: generic/fedora39
     memory: 1024
     cpus: 2
     provider_raw_config_args:

--- a/molecule/kvm/molecule.yml
+++ b/molecule/kvm/molecule.yml
@@ -164,6 +164,10 @@ provisioner:
     ansible_become: true
   log: true
   lint: yamllint . && flake8 && ansible-lint
+  inventory:
+    host_vars:
+      test-lvm-arch:
+        ansible_python_interpreter: "/usr/bin/python3"
 
 scenario:
   name: kvm

--- a/molecule/kvm/molecule.yml
+++ b/molecule/kvm/molecule.yml
@@ -34,17 +34,6 @@ platforms:
         network_name: private_network
         type: static
         ip: 192.168.10.20
-  - name: test-lvm-debian10
-    box: generic/debian10
-    memory: 1024
-    cpus: 2
-    provider_raw_config_args:
-      - "storage :file, :type => 'qcow2', :device => 'vdb', :size => '1G'"
-    interfaces:
-      - auto_config: true
-        network_name: private_network
-        type: static
-        ip: 192.168.10.40
   - name: test-lvm-fedora35
     box: generic/fedora35
     memory: 1024

--- a/molecule/kvm/prepare.yml
+++ b/molecule/kvm/prepare.yml
@@ -2,28 +2,39 @@
 # Copyright (C) 2021-2024 Robert Wimmer
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-- hosts: all
+- name: Prepare Archlinux
+  hosts: test-lvm-arch
+  remote_user: vagrant
+  become: true
+  gather_facts: false
+  tasks:
+    - name: Init pacman
+      ansible.builtin.raw: |
+        pacman-key --init
+        pacman-key --populate archlinux
+      changed_when: false
+      failed_when: false
+
+    - name: Updating pacman cache
+      ansible.builtin.raw: pacman -Sy
+      changed_when: false
+      failed_when: false
+
+    - name: Install Python
+      ansible.builtin.raw: |
+        pacman -S --noconfirm python
+      args:
+        executable: /bin/bash
+      changed_when: false
+
+- name: Prepare Ubuntu
+  hosts: all
   remote_user: vagrant
   become: true
   gather_facts: true
   tasks:
-    - name: (Archlinux) setup
-      block:
-        - name: (Archlinux) Init pacman
-          raw: |
-            pacman-key --init
-            pacman-key --populate archlinux
-          changed_when: false
-          ignore_errors: true
-
-        - name: (Archlinux) Update pacman cache
-          community.general.pacman:
-            update_cache: true
-          changed_when: false
-      when: ansible_distribution | lower == 'archlinux'
-
     - name: (Ubuntu) Update APT package cache
-      apt:
+      when: ansible_distribution | lower == 'ubuntu'
+      ansible.builtin.apt:
         update_cache: true
         cache_valid_time: 3600
-      when: ansible_distribution | lower == 'ubuntu'

--- a/molecule/kvm/prepare.yml
+++ b/molecule/kvm/prepare.yml
@@ -1,5 +1,5 @@
 ---
-# Copyright (C) 2021-2022 Robert Wimmer
+# Copyright (C) 2021-2024 Robert Wimmer
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 - hosts: all

--- a/molecule/kvm/vars/test-lvm-arch_create.yml
+++ b/molecule/kvm/vars/test-lvm-arch_create.yml
@@ -1,5 +1,5 @@
 ---
-# Copyright (C) 2021-2022 Robert Wimmer
+# Copyright (C) 2021-2024 Robert Wimmer
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 lvm_vgs:

--- a/molecule/kvm/vars/test-lvm-arch_delete.yml
+++ b/molecule/kvm/vars/test-lvm-arch_delete.yml
@@ -1,5 +1,5 @@
 ---
-# Copyright (C) 2021-2022 Robert Wimmer
+# Copyright (C) 2021-2024 Robert Wimmer
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 lvm_vgs:

--- a/molecule/kvm/vars/test-lvm-minimal.yml
+++ b/molecule/kvm/vars/test-lvm-minimal.yml
@@ -1,5 +1,5 @@
 ---
-# Copyright (C) 2021-2022 Robert Wimmer
+# Copyright (C) 2021-2024 Robert Wimmer
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 lvm_vgs:

--- a/molecule/kvm/vars/test-lvm-ubuntu2004_create.yml
+++ b/molecule/kvm/vars/test-lvm-ubuntu2004_create.yml
@@ -1,5 +1,5 @@
 ---
-# Copyright (C) 2021-2022 Robert Wimmer
+# Copyright (C) 2021-2024 Robert Wimmer
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 lvm_vgs:

--- a/tasks/delete_fs.yml
+++ b/tasks/delete_fs.yml
@@ -1,5 +1,5 @@
 ---
-# Copyright (C) 2021-2022 Robert Wimmer
+# Copyright (C) 2021-2024 Robert Wimmer
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 - name: Delete filesystems marked for deletion

--- a/tasks/delete_lvs.yml
+++ b/tasks/delete_lvs.yml
@@ -1,5 +1,5 @@
 ---
-# Copyright (C) 2021-2022 Robert Wimmer
+# Copyright (C) 2021-2024 Robert Wimmer
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 - name: Delete logical volumes marked for deletion

--- a/tasks/delete_vgs.yml
+++ b/tasks/delete_vgs.yml
@@ -1,5 +1,5 @@
 ---
-# Copyright (C) 2021-2022 Robert Wimmer
+# Copyright (C) 2021-2024 Robert Wimmer
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 - name: Delete volume group(s) marked for deletion

--- a/tasks/ensure_fs.yml
+++ b/tasks/ensure_fs.yml
@@ -1,5 +1,5 @@
 ---
-# Copyright (C) 2021-2022 Robert Wimmer
+# Copyright (C) 2021-2024 Robert Wimmer
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 - name: Ensure filesystems

--- a/tasks/ensure_lvs.yml
+++ b/tasks/ensure_lvs.yml
@@ -12,7 +12,7 @@
     thinpool: "{{ item.1.thinpool | default(omit) }}"
     size: "{{ item.1.size }}"
     state: "{{ item.1.state }}"
-    resizefs: "{{ item.1.resizefs }}"
+    resizefs: "{{ item.1.resizefs | default(omit) }}"
   loop: "{{ q('subelements', lvm_vgs, 'lvm_lvs', {'skip_missing': True}) }}"
   loop_control:
     label: >

--- a/tasks/ensure_lvs.yml
+++ b/tasks/ensure_lvs.yml
@@ -1,5 +1,5 @@
 ---
-# Copyright (C) 2021-2022 Robert Wimmer
+# Copyright (C) 2021-2024 Robert Wimmer
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 - name: Ensure logical volumes

--- a/tasks/ensure_vgs.yml
+++ b/tasks/ensure_vgs.yml
@@ -1,5 +1,5 @@
 ---
-# Copyright (C) 2021-2022 Robert Wimmer
+# Copyright (C) 2021-2024 Robert Wimmer
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 - name: Ensure volume group(s)

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,5 +1,5 @@
 ---
-# Copyright (C) 2021-2022 Robert Wimmer
+# Copyright (C) 2021-2024 Robert Wimmer
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 - name: Gather instance facts

--- a/tasks/mounts.yml
+++ b/tasks/mounts.yml
@@ -3,6 +3,11 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 - name: Tasks for handling mountpoints
+  when:
+    - item.1.fs is defined
+    - item.1.fs.mountpoint is defined
+  tags:
+    - lvm-mounts
   block:
     - name: Directories for mountpoints
       ansible.builtin.file:
@@ -33,8 +38,3 @@
                 default('/dev/' + item.0.vgname + '/' + item.1.lvname) }} -> {{ item.1.fs.mountpoint.path.name |
                 default('no mount') }}: {{ item.1.fs.mountpoint.state |
                 default('no state') }}"
-  when:
-    - item.1.fs is defined
-    - item.1.fs.mountpoint is defined
-  tags:
-    - lvm-mounts

--- a/tasks/mounts.yml
+++ b/tasks/mounts.yml
@@ -4,7 +4,7 @@
 
 - name: Tasks for handling mountpoints
   block:
-    - name: Directries for mountpoints
+    - name: Directories for mountpoints
       ansible.builtin.file:
         path: "{{ item.1.fs.mountpoint.path.name }}"
         state: directory

--- a/tasks/mounts.yml
+++ b/tasks/mounts.yml
@@ -1,5 +1,5 @@
 ---
-# Copyright (C) 2021-2022 Robert Wimmer
+# Copyright (C) 2021-2024 Robert Wimmer
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 - name: Tasks for handling mountpoints

--- a/tasks/setup-archlinux.yml
+++ b/tasks/setup-archlinux.yml
@@ -1,5 +1,5 @@
 ---
-# Copyright (C) 2021-2022 Robert Wimmer
+# Copyright (C) 2021-2024 Robert Wimmer
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 - name: (Archlinux compatible OS) Install required packages

--- a/tasks/setup-debian.yml
+++ b/tasks/setup-debian.yml
@@ -1,5 +1,5 @@
 ---
-# Copyright (C) 2021-2022 Robert Wimmer
+# Copyright (C) 2021-2024 Robert Wimmer
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 - name: (Debian compatible OS) Install required packages

--- a/tasks/setup-redhat.yml
+++ b/tasks/setup-redhat.yml
@@ -1,5 +1,5 @@
 ---
-# Copyright (C) 2021-2022 Robert Wimmer
+# Copyright (C) 2021-2024 Robert Wimmer
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 - name: (RedHat compatible OS) Install required packages

--- a/tasks/setup-suse.yml
+++ b/tasks/setup-suse.yml
@@ -1,5 +1,5 @@
 ---
-# Copyright (C) 2021-2022 Robert Wimmer
+# Copyright (C) 2021-2024 Robert Wimmer
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 - name: (SuSE compatible OS) Install required packages


### PR DESCRIPTION
- add resize filesystem `resizefs` item
- remove support for Ubuntu 18.04 (reached EOL)
- remove support for Debian 10 (reached EOL)
- remove support for Fedora 35/36 (reached EOL)
- remove support for openSUSE Leap 15.3 (reached EOL)
- add support for Fedora 39
- add support for Debian 12
- add support for openSUSE Leap 15.4
- add support for openSUSE Leap 15.5
- add support for Rocky Linux 8/9
- add support for Almalinux 8/9
- update Github workflow
- Molecule: change IP addresses
- Molecule: fix ansible-lint issues